### PR TITLE
Add guards to the role for multi-node clouds

### DIFF
--- a/tasks/telegraf_post_install_haproxy.yml
+++ b/tasks/telegraf_post_install_haproxy.yml
@@ -1,12 +1,14 @@
 - name: Get stats socket path
   shell: gawk '/stats socket/ {print $3}' /etc/haproxy/haproxy.cfg
   register: haproxy_stats_socket
+  failed_when: false
   tags:
     - telegraf_client-config
 
 - name: Add telegraf to haclient group
   user: name=telegraf append=yes groups=haclient
   when:
+    - haproxy_stats_socket.rc == 0
     - inventory_hostname in groups['network_all']
     - ansible_virtualization_role != 'host' # Already run as root
   notify:
@@ -20,6 +22,8 @@
     dest: "{{ item.dest }}"
     owner: "root"
     group: "root"
+  when:
+    - haproxy_stats_socket.rc == 0
   with_items:
     - { src: "haproxy.conf.j2", dest: "/etc/telegraf/telegraf.d/haproxy.conf" }
   notify:

--- a/tasks/telegraf_post_install_scripts.yml
+++ b/tasks/telegraf_post_install_scripts.yml
@@ -8,6 +8,7 @@
   with_dict: "{{ telegraf_openstack_scripts }}"
   when:
     - item.value.when_group | bool
+    - item.value.plugin_source_path is defined
     - item.value.group == inventory_hostname or inventory_hostname in item.value.group | default([])
   tags:
     - telegraf_client-config

--- a/templates/cgroup.conf.j2
+++ b/templates/cgroup.conf.j2
@@ -16,11 +16,12 @@
 		"/sys/fs/cgroup/memory/system.slice/keepalived.service/",
 		#"/sys/fs/cgroup/blkio/system.slice/keepalived.service/"
 {% endif %}
-{% if inventory_hostname in groups['compute_hosts'] and nova_virt_type == 'lxd' %}
+{% if inventory_hostname in groups['compute_hosts'] and nova_virt_type | default('kvm') == 'lxd' %}
 		# Compute hosts with LXD
 		"/sys/fs/cgroup/cpuacct/lxc/",
 		"/sys/fs/cgroup/memory/lxc/",
 		#"/sys/fs/cgroup/blkio/lxc/",
+{% endif %}
 {% if inventory_hostname in groups['compute_hosts'] %}
 		# Compute hosts common
 		"/sys/fs/cgroup/cpuacct/neutron.slice/",

--- a/templates/telegraf.sudo.j2
+++ b/templates/telegraf.sudo.j2
@@ -3,7 +3,9 @@
 {% set run_commands = [] %}
 {% for key, value in telegraf_openstack_scripts.items() %}
 {% 	if value.when_group | bool and (value.group == inventory_hostname or inventory_hostname in value.group | default([])) %}
+{%   if value.sudoers_entry is defined %}
 {% 		set _ = run_commands.extend(value.sudoers_entry) %}
+{% 	 endif %}
 {% 	endif %}
 {% endfor %}
 


### PR DESCRIPTION
This change adds a missing endif block in the cgroup template and sets a
default for the nova virt type should it be undefined. This change also
adds guards around the haproxy and scripts task files so that both local
scripts to this role and upstream osa scripts can be used at the same
time. The sudo template was updated to ensure success by making sure
required variables are defined.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>